### PR TITLE
fixed \r\n

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -2039,7 +2039,7 @@ var JWTInternals = (function() {
 
   function base64urlencode(arg)
   {
-    var s = Ti.Utils.base64encode(arg).toString(); // Standard base64 encoder
+    var s = Ti.Utils.base64encode(arg).toString().replace(/\r?\n|\r/g, ""); // Standard base64 encoder
     s = s.split('=')[0]; // Remove any trailing '='s
     s = s.replace(/\+/g, '-'); // 62nd char of encoding
     s = s.replace(/\//g, '_'); // 63rd char of encoding


### PR DESCRIPTION
if payload is a bit more large JSON, the token cannot be verified by jwt.io due to "\n", now fixed.

![unnamed](https://cloud.githubusercontent.com/assets/3412867/15995853/b7f1aa4e-3153-11e6-8889-458460589d70.png)
